### PR TITLE
fix typo

### DIFF
--- a/Yakitori.WPF/Views/SettingWindow.xaml
+++ b/Yakitori.WPF/Views/SettingWindow.xaml
@@ -65,7 +65,7 @@
 						  Unchecked="Value_Changed" />
 				<TextBox Text="{Binding Source={x:Static p:Settings.Default}, Path=Count, Mode=TwoWay}"
 						 TextChanged="TextBox_TextChanged"/>
-				<TextBlock Text="minutes." />
+				<TextBlock Text="seconds." />
 			</StackPanel>
 
 			<CheckBox Content="Play sound after you take a screenshot." 


### PR DESCRIPTION
[MoonGift](https://www.moongift.jp/2021/02/yakitori-windows-10%e3%81%ae%e3%82%b9%e3%82%af%e3%83%aa%e3%83%bc%e3%83%b3%e3%82%b7%e3%83%a7%e3%83%83%e3%83%88%e3%82%92%e7%b0%a1%e5%8d%98%e3%81%ab/?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+moongift+%28MOONGIFT+-+%3F%3F%3F%3F%3F%3F%3F%3F%3F%3FIT%3F%3F%3F%3F+-%29)でこのツールを知り、ダウンロードして使ってます。

ちょっとしたTypoがあったので修正しました。

### 1ユーザのフィードバックとして

「Seleted Rect」でキャプチャした時はキャプチャの通知が出てくれるのですが、「Desktop」と「Active Window」をキャプチャした時も通知が同じように出てきてくれると嬉しいです。

上記の実行環境は以下です。

- Windows10 Enterprise 1909（18363.1316）

以上、よろしくお願いします・